### PR TITLE
Use appropriate key name for level

### DIFF
--- a/src/canadiantracker/triangle.py
+++ b/src/canadiantracker/triangle.py
@@ -12,6 +12,7 @@ class _ProductCategory:
     def __init__(self, name: str, pretty_name: str):
         self._name = name
         self._pretty_name = pretty_name
+        self._num_levels = len(name.split("::"))
 
     @property
     def name(self) -> str:
@@ -20,6 +21,11 @@ class _ProductCategory:
     @property
     def pretty_name(self) -> str:
         return self._pretty_name
+
+    @property
+    def num_levels(self) -> int:
+        """Number of levels in the category."""
+        return self._num_levels
 
 
 class ProductInventory(Iterable):
@@ -53,8 +59,9 @@ class ProductInventory(Iterable):
             # Limiting ourselves to level 1 and 2 categories appears to allow
             # us to list most products while also limiting the number of products
             # re-listed for nothing.
-            if len(name.split("::")) == 1 or len(name.split("::")) == 2:
-                self._product_categories.append(_ProductCategory(name, pretty_name))
+            cat = _ProductCategory(name, pretty_name)
+            if cat.num_levels == 1 or cat.num_levels == 2:
+                self._product_categories.append(cat)
 
                 if (
                     dev_max_categories != 0
@@ -93,7 +100,7 @@ class ProductInventory(Iterable):
         params = {"site": "ct", "page": page_number, "format": "json"}
 
         if category:
-            params["x1"] = "ast-id-level-1"
+            params["x1"] = f"ast-id-level-{category.num_levels}"
             params["q1"] = category.name
 
         return requests.get(


### PR DESCRIPTION
I don't know if it matters, but we use the search key "ast-id-level-1"
for all product searches by category.  If you browse here, for example:

    https://www.canadiantire.ca/en/kitchen/cookware/fry-pans.html?adlocation=LOL_DLP_Living_Kitchen_Cookware_FryPans_en

and look at the API requests done, you'll see:

    https://api.canadiantire.ca/search/api/v0/product/en/?site=ct%3Bstore%3D0064%3Bformat%3Djson%3Bcount%3D32%3Bx1%3Dast-id-level-3%3Bq1%3Dkitchen%3A%3Acookware%3A%3Afry-pans%3Bq%3D*%3Bcallback%3Dcallback

We see that the key is ast-id-level-3, which matches the number of
levels in the category kitchen::cookware::fry-pans.

Change the code to use the correct key name, based on the number of
levels in the category.  I didn't notice any changes in behaviors
though.