### PR TITLE
Record URL in products_static table

### DIFF
--- a/alembic/versions/8fe398b58b5f_products_static_add_product_url.py
+++ b/alembic/versions/8fe398b58b5f_products_static_add_product_url.py
@@ -1,0 +1,24 @@
+"""products_static: add product url
+
+Revision ID: 8fe398b58b5f
+Revises: ac4b7897c153
+Create Date: 2022-06-07 21:11:10.517608
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "8fe398b58b5f"
+down_revision = "ac4b7897c153"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("products_static", sa.Column("url", sa.String()))
+
+
+def downgrade():
+    op.drop_column("products_static", "url")

--- a/src/canadiantracker/model.py
+++ b/src/canadiantracker/model.py
@@ -31,10 +31,11 @@ class ProductInfo:
 
 
 class ProductListingEntry:
-    def __init__(self, code: str, name: str, is_in_clearance: bool):
+    def __init__(self, code: str, name: str, is_in_clearance: bool, url: str):
         self._code = code
         self._name = name
         self._is_in_clearance = is_in_clearance
+        self._url = url
 
     def __str__(self) -> str:
         return "[{code}] {name}".format(code=self._code, name=self._name)
@@ -50,6 +51,10 @@ class ProductListingEntry:
     @property
     def is_in_clearance(self):
         return self._is_in_clearance
+
+    @property
+    def url(self):
+        return self._url
 
     def __repr__(self):
         props = {

--- a/src/canadiantracker/triangle.py
+++ b/src/canadiantracker/triangle.py
@@ -153,6 +153,7 @@ class ProductInventory(Iterable):
                         product["field"]["prod-id"],
                         product["field"]["prod-name"],
                         product["field"]["clearance"] == "T",
+                        product["field"]["pdp-url"],
                     )
 
                 if (


### PR DESCRIPTION
It would be useful to have the URL to the product to be able to provide
links from third party tools to the Canadian Tire website.  This patch
makes ctscraper record the url (e.g.
`/en/pdp/antiskid-sand-10-kg-0597113p.html`) in the products_static
table.

Provide a new migration script to add a `url` column in that table.  The
migration can be applied by running

  $ CTRACKER_DB_PATH=test.db poetry run alembic upgrade head

The migration must be applied before attempting to run the code in this
patch.

When scraping a product and an entry already exists, check whether the
url property is None (NULL in SQL), and if so update it.