### PR TITLE
Check that the database file exists

### DIFF
--- a/src/canadiantracker/query.py
+++ b/src/canadiantracker/query.py
@@ -57,7 +57,7 @@ def price_history(db_path: str, format: str, product_code: str) -> None:
     product_code = product_code.upper()
 
     repository = canadiantracker.storage.get_product_repository_from_sqlite_file(
-        db_path, should_create=False
+        db_path
     )
 
     if repository.get_product_listing_by_code(product_code) is None:

--- a/src/canadiantracker/scraper.py
+++ b/src/canadiantracker/scraper.py
@@ -82,7 +82,7 @@ def scrape_inventory(
     """
 
     repository = canadiantracker.storage.get_product_repository_from_sqlite_file(
-        db_path, should_create=True
+        db_path
     )
     inventory = canadiantracker.triangle.ProductInventory(
         dev_max_categories=dev_max_categories,
@@ -130,7 +130,7 @@ def scrape_prices(db_path: str, older_than: int) -> None:
     Fetch current product prices.
     """
     repository = canadiantracker.storage.get_product_repository_from_sqlite_file(
-        db_path, should_create=True
+        db_path
     )
 
     progress_bar_settings = {

--- a/src/canadiantracker/storage.py
+++ b/src/canadiantracker/storage.py
@@ -86,13 +86,17 @@ class ProductRepository:
 
 class _SQLite3ProductRepository(ProductRepository):
     def __init__(self, path: str):
+        if not os.path.exists(path):
+            raise RuntimeError(f"Database {path} does not exist.")
+
         db_url = "sqlite:///" + os.path.abspath(path)
         logger.debug("Creating SQLite3ProductRepository with url `%s`", db_url)
         self._engine = sqlalchemy.create_engine(db_url, echo=False)
         self._session = sqlalchemy.orm.sessionmaker(bind=self._engine)()
 
     def __del__(self):
-        self._session.commit()
+        if hasattr(self, '_session'):
+            self._session.commit()
 
     @property
     def products(self) -> Iterator[canadiantracker.model.ProductListingEntry]:

--- a/src/canadiantracker/storage.py
+++ b/src/canadiantracker/storage.py
@@ -153,7 +153,5 @@ class _SQLite3ProductRepository(ProductRepository):
             self._session.add(new_sample)
 
 
-def get_product_repository_from_sqlite_file(
-    path: str, should_create: bool
-) -> ProductRepository:
+def get_product_repository_from_sqlite_file(path: str) -> ProductRepository:
     return _SQLite3ProductRepository(path)


### PR DESCRIPTION
Add a check to make sure that the database file exists before trying to open it.  This avoids sqlite creating an empty database file, which makes the program then error out with unclear error messages.  The first patch is a little cleanup.