### PR TITLE
scraper: incorrect field scraped for sku attribute

### DIFF
--- a/src/canadiantracker/triangle.py
+++ b/src/canadiantracker/triangle.py
@@ -154,7 +154,7 @@ class ProductInventory(Iterable):
                         product["field"]["prod-name"],
                         product["field"]["clearance"] == "T",
                         product["field"]["pdp-url"],
-                        product["field"]["sku-id"],
+                        product["field"]["sku-number"],
                     )
 
                 if (


### PR DESCRIPTION
`sku-id` contains the product code without the 'P' suffix, whereas `sku-number` contains the actual "display product name" we care about.

This doesn't work smoothly for products that are a "category" of products (e.g. tires of different sizes). In those cases, it will result in a list of `|`-separated skus.