### PR TITLE
http: show product sku on product page

### DIFF
--- a/src/canadiantracker/http.py
+++ b/src/canadiantracker/http.py
@@ -55,9 +55,18 @@ async def products(request: Request):
     return _templates.TemplateResponse("index.html", {"request": request})
 
 
+def sanitize_sku(listing: ProductListingEntry) -> str:
+    if not listing.sku:
+        return listing.code
+
+    return listing.sku.split("|")[0]
+
+
 @app.get("/products/{product_id}", response_class=HTMLResponse)
 async def one_product(request: Request, product_id):
     listing = _repository.get_product_listing_by_code(product_id)
+
+    listing.sku = sanitize_sku(listing)
 
     return _templates.TemplateResponse(
         "product.html", {"request": request, "listing": listing}

--- a/src/canadiantracker/web/templates/product.html
+++ b/src/canadiantracker/web/templates/product.html
@@ -59,7 +59,7 @@
     <p>
         Name: {{ listing.name }}
         <br>
-        Code: {{ listing.code }}
+        <a href="https://canadiantire.ca{{ listing.url }}">{{ listing.sku }}</a>
     </p>
 
     <div id="price-history" style="width:600px;height:250px;"></div>


### PR DESCRIPTION
SKUs are sanitized in a pretty crude way since they can contain a list of SKUs for product categories. Our support for such categories is already pretty shaky, so I think this is the best we can do right now.
