### PR TITLE
storage: verify alembic revision id when opening database

### DIFF
--- a/src/canadiantracker/cli_utils.py
+++ b/src/canadiantracker/cli_utils.py
@@ -1,0 +1,19 @@
+import sys
+
+from canadiantracker.storage import (
+    InvalidDatabaseRevisionException,
+    ProductRepository,
+    get_product_repository_from_sqlite_file,
+)
+
+
+def get_product_repository_from_sqlite_file_check_version(
+    path: str,
+) -> ProductRepository:
+    try:
+        return get_product_repository_from_sqlite_file(path)
+    except InvalidDatabaseRevisionException as e:
+        print(e)
+        print()
+        print("Make sure the database is at the latest revision.")
+        sys.exit(1)

--- a/src/canadiantracker/query.py
+++ b/src/canadiantracker/query.py
@@ -7,6 +7,9 @@ import logging
 import textwrap
 import decimal
 from collections.abc import Iterator
+from canadiantracker.cli_utils import (
+    get_product_repository_from_sqlite_file_check_version,
+)
 
 import canadiantracker.storage
 import canadiantracker.model
@@ -56,9 +59,7 @@ def price_history(db_path: str, format: str, product_code: str) -> None:
     # capitalization patterns by the website and APIs.
     product_code = product_code.upper()
 
-    repository = canadiantracker.storage.get_product_repository_from_sqlite_file(
-        db_path
-    )
+    repository = get_product_repository_from_sqlite_file_check_version(db_path)
 
     if repository.get_product_listing_by_code(product_code) is None:
         click.echo(

--- a/src/canadiantracker/scraper.py
+++ b/src/canadiantracker/scraper.py
@@ -2,6 +2,9 @@ import click
 import sys
 import logging
 import textwrap
+from canadiantracker.cli_utils import (
+    get_product_repository_from_sqlite_file_check_version,
+)
 
 import canadiantracker.triangle
 import canadiantracker.storage
@@ -81,9 +84,7 @@ def scrape_inventory(
     Fetch static product properties.
     """
 
-    repository = canadiantracker.storage.get_product_repository_from_sqlite_file(
-        db_path
-    )
+    repository = get_product_repository_from_sqlite_file_check_version(db_path)
     inventory = canadiantracker.triangle.ProductInventory(
         dev_max_categories=dev_max_categories,
         dev_max_pages_per_category=dev_max_pages_per_category,
@@ -129,8 +130,10 @@ def scrape_prices(db_path: str, older_than: int) -> None:
     """
     Fetch current product prices.
     """
-    repository = canadiantracker.storage.get_product_repository_from_sqlite_file(
-        db_path
+    repository = (
+        canadiantracker.storage.get_product_repository_from_sqlite_file_check_version(
+            db_path
+        )
     )
 
     progress_bar_settings = {


### PR DESCRIPTION
On of my greatest fears is to run the Canadian Tracker code with a
database that is at the wrong migration, possibly corrupting the data.
To avoid this, I propose to add a check, when opening the database, that
the database is at the right revision.

This also helps for the case of specifying a file that doesn't exist as
the database.  We recently added a file existence check for that
recently, this patch makes it not really needed anymore.  With this
patch, when specifying a file that doesn't exist, an empty sqlite
database will be created, but the program will error out with:

    Database is missing the alembic_version table. Make sure it is initialized correctly.

The user can then run the necessary "alembic upgrade head" command to
populate the database.

When the revision is not the right one, the message is:

    Failed to validate database revision: expected 8fe398b58b5f, got ac4b7897c153

    Make sure the database is at the latest revision.