### PR TITLE
web: remove markers in graph

### DIFF
--- a/src/canadiantracker/web/templates/product.html
+++ b/src/canadiantracker/web/templates/product.html
@@ -37,7 +37,7 @@
                     x: xs,
                     y: ys,
                     type: 'scatter',
-                    mode: 'lines+markers',
+                    mode: 'lines',
                 }]);
             });
             console.log(code);


### PR DESCRIPTION
The Canadian Tracker steering committee has ruled that the price graph
would more visually appealing withouth the markers.  Make it so.