### PR TITLE
Add SKUs table, use newer API to fetch data

### DIFF
--- a/alembic/versions/9169a7c5bda3_add_skus_table.py
+++ b/alembic/versions/9169a7c5bda3_add_skus_table.py
@@ -1,0 +1,222 @@
+"""add skus table
+
+Revision ID: 9169a7c5bda3
+Revises: 4e2a96338a6c
+Create Date: 2022-06-20 09:59:54.418820
+
+"""
+from alembic import op
+import sqlalchemy as sa
+import re
+
+
+# revision identifiers, used by Alembic.
+revision = "9169a7c5bda3"
+down_revision = "4e2a96338a6c"
+branch_labels = None
+depends_on = None
+
+# Ensure the formatting of `sku` is "123-4567-8" (i.e. add the possibly missing
+# leading zeros).
+def normalize_formatted_sku_code(sku):
+    if re.match(r"\d-\d\d\d\d-\d", sku):
+        sku = "0" + sku
+
+    if re.match(r"\d\d-\d\d\d\d-\d", sku):
+        sku = "0" + sku
+
+    if not re.match(r"\d\d\d-\d\d\d\d-\d", sku):
+        raise RuntimeError(f"Unexpected sku code format: `{sku}`")
+
+    return sku
+
+
+# Convert a formatted SKU code (123-4567-8) to its "internal" form (1234567).
+def sku_code_from_formatted_sku_code(c):
+    assert re.match(r"\d\d\d-\d\d\d\d-\d", c)
+    return c[0:3] + c[4:8]
+
+
+def upgrade():
+    db = op.get_bind()
+
+    metadata = sa.MetaData()
+    products_static_table = sa.Table(
+        "products_static", metadata, autoload_with=op.get_bind().engine
+    )
+    products_dynamic_table = sa.Table(
+        "products_dynamic", metadata, autoload_with=op.get_bind().engine
+    )
+
+    # Store all SKU values to insert here, do one batch insert at the end.
+    sku_values = []
+
+    # In the current schema, for products with multiple SKUs, the `sku` column
+    # of the `products_static` table contains a `|`-separated list of SKU codes,
+    # like:
+    #
+    #   9-0309-0|9-0308-2|9-0307-4|9-0328-4
+    #
+    # In this migration, we introduce a separate `skus` table, where each SKU
+    # gets an entry.  We then drop the `sku` column of the `products_static`
+    # table.
+
+    # For each product...
+    print(">>> Reading product list, generating SKU list")
+    for (
+        index,
+        name,
+        product_code,
+        is_in_clearance,
+        last_listed,
+        url,
+        sku_codes,
+    ) in db.execute(sa.select(products_static_table)):
+        if sku_codes is None:
+            # Some entries in the Officiel Database don't contain a SKU, maybe
+            # because they are stale... in any case, we can't do any case with
+            # those right now.
+            continue
+
+        # For each SKU code...
+        for formatted_sku_code in sku_codes.split("|"):
+            formatted_sku_code = normalize_formatted_sku_code(formatted_sku_code)
+            sku_code = sku_code_from_formatted_sku_code(formatted_sku_code)
+
+            sku_values.append(
+                {
+                    "code": sku_code,
+                    "formatted_code": formatted_sku_code,
+                    "product_index": index,
+                }
+            )
+
+    print(">>> Creating skus table")
+    # Now that we know the data looks sane, create the new table.
+    skus_table = op.create_table(
+        "skus",
+        sa.Column("index", sa.Integer, nullable=False),
+        sa.Column("code", sa.String, nullable=False),
+        sa.Column("formatted_code", sa.String),
+        sa.Column("product_index", sa.Integer, nullable=False),
+        sa.ForeignKeyConstraint(
+            ["product_index"],
+            ["products_static.index"],
+        ),
+        sa.PrimaryKeyConstraint("index"),
+    )
+
+    # Create an index on skus.code, we'll want to look up SKUs by code.
+    op.create_index(None, "skus", ["code"], unique=True)
+
+    # Insert SKU rows.
+    op.bulk_insert(skus_table, sku_values)
+
+    # Build an in-memory sku code -> sku index map, to speed up lookups lower
+    # (avoid doing millions of SQL queries when migrating the samples).
+    sku_code_to_index = {}
+    for (index, code, formatted_code, product_index) in db.execute(
+        sa.select(skus_table)
+    ):
+        sku_code_to_index[code] = index
+
+    print(">>> Dropping products_static.sku column")
+    # Drop the `sku` column.
+    op.drop_column("products_static", "sku")
+
+    # Create a new table for the samples
+    print(">>> Creating samples table")
+    samples_table = op.create_table(
+        "samples",
+        sa.Column("index", sa.Integer(), nullable=False),
+        sa.Column("sample_time", sa.DateTime(), nullable=False),
+        sa.Column("sku_index", sa.String(), nullable=False),
+        sa.Column("price", sa.Numeric(), nullable=False),
+        sa.Column("in_promo", sa.Boolean(), nullable=False),
+        sa.Column("raw_payload", sa.String(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["sku_index"],
+            ["skus.index"],
+        ),
+        sa.PrimaryKeyConstraint("index"),
+    )
+
+    # Go over each sample.
+    print(">>> Generating new sample values")
+    i = 0
+    sample_values = []
+    sample_count = db.execute(
+        sa.select(sa.func.count(products_dynamic_table.columns.index))
+    ).fetchone()[0]
+    for index, sample_time, code, price, in_promo, raw_payload in db.execute(
+        sa.select(products_dynamic_table)
+    ):
+        raw = eval(raw_payload)
+
+        # Only keep samples that have an explicit SKU value.
+        if "SKU" not in raw:
+            continue
+
+        if raw["PriceFrom"] == "Y":
+            continue
+
+        sku_code = raw["SKU"]
+
+        # There are products for which we didn't have a SKU list (maybe items
+        # that don't exist anymore?), so there is no SKU row for those.
+        #
+        # For those, see if there is a product with that code, and create a SKU
+        # entry from that.
+        if sku_code not in sku_code_to_index:
+            print(f"Could not find SKU with code {sku_code}")
+            prod_row = db.execute(
+                sa.text(
+                    f'SELECT "index" FROM products_static WHERE code = :sku_code LIMIT 1'
+                ),
+                {"sku_code": sku_code + "P"},
+            ).first()
+            if prod_row is not None:
+                product_index = prod_row[0]
+                print(
+                    f"  -> Found a product with that code (index {product_index}), creating a SKU from that"
+                )
+                ret = db.execute(
+                    sa.insert(skus_table).values(
+                        {"code": sku_code, "product_index": product_index}
+                    )
+                )
+
+                # Maintain our in-memory sku code -> sku index map.
+                sku_index = ret.inserted_primary_key[0]
+                sku_code_to_index[sku_code] = sku_index
+            else:
+                # No SKU nor product with that code.  Weird, but there's nothing we can do.
+                print(f"  -> Could not find product with that code, dropping sample")
+                continue
+
+        sku_index = sku_code_to_index[sku_code]
+
+        sample_values.append(
+            {
+                "sample_time": sample_time,
+                "sku_index": sku_index,
+                "price": price,
+                "in_promo": in_promo,
+                "raw_payload": raw_payload,
+            }
+        )
+
+        i += 1
+        if i % 10000 == 0:
+            print(f"{i}/{sample_count}")
+
+    print(">>> Inserting new samples")
+    op.bulk_insert(samples_table, sample_values)
+
+    print(">>> Dropping products_dynamic table")
+    op.drop_table("products_dynamic")
+
+
+def downgrade():
+    # No way I'm implementing this.
+    raise NotImplementedError

--- a/src/canadiantracker/http.py
+++ b/src/canadiantracker/http.py
@@ -5,7 +5,7 @@ from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
 import canadiantracker.storage
-from canadiantracker.model import ProductInfo, ProductInfoSample, ProductListingEntry
+from canadiantracker.model import ProductInfo, ProductInfoSample, Sku
 
 app = FastAPI()
 _db_path = os.environ["CTSERVER_SERVE_DB_PATH"]
@@ -42,10 +42,21 @@ def serialize_product_info_sample(sample: ProductInfoSample) -> dict:
     }
 
 
-@app.get("/api/products/{product_id}/samples")
-async def api_product_samples(product_id: str) -> list[dict]:
-    samples = _repository.get_product_info_samples_by_code(product_id)
-    return [serialize_product_info_sample(sample) for sample in samples]
+def serialize_sku(sku: Sku) -> dict:
+    return {"code": sku.code, "formatted_code": sku.formatted_code}
+
+
+@app.get("/api/products/{product_code}")
+async def api_product(product_code: str) -> dict:
+    product = _repository.get_product_listing_by_code(product_code)
+
+    return {"skus": [serialize_sku(sku) for sku in product.skus]}
+
+
+@app.get("/api/skus/{sku_code}/samples")
+async def api_skus_samples(sku_code: str) -> list[dict]:
+    sku = _repository.get_sku_by_code(sku_code)
+    return [serialize_product_info_sample(sample) for sample in sku.samples]
 
 
 @app.get("/", response_class=HTMLResponse)
@@ -54,21 +65,34 @@ async def products(request: Request) -> Jinja2Templates.TemplateResponse:
     return _templates.TemplateResponse("index.html", {"request": request})
 
 
-def sanitize_sku(listing: ProductListingEntry) -> str:
-    if not listing.sku:
-        return listing.code
-
-    return listing.sku.split("|")[0]
-
-
-@app.get("/products/{product_id}", response_class=HTMLResponse)
+@app.get("/products/{product_code}", response_class=HTMLResponse)
 async def one_product(
-    request: Request, product_id: str
+    request: Request, product_code: str
 ) -> Jinja2Templates.TemplateResponse:
-    listing = _repository.get_product_listing_by_code(product_id)
-
-    listing.sku = sanitize_sku(listing)
-
+    product = _repository.get_product_listing_by_code(product_code)
     return _templates.TemplateResponse(
-        "product.html", {"request": request, "listing": listing}
+        "product.html", {"request": request, "product": product}
+    )
+
+
+def make_sku_url(sku_code: str, product_url: str) -> str:
+    """Derive the url for sku SKU_CODE, given that the url for the product
+    is PRODUCT_URL."""
+    if not product_url.endswith("p.html"):
+        return None
+
+    return product_url[0:-4] + sku_code + ".html"
+
+
+@app.get("/skus/{sku_code}", response_class=HTMLResponse)
+async def one_sku(request: Request, sku_code: str) -> Jinja2Templates.TemplateResponse:
+    sku = _repository.get_sku_by_code(sku_code)
+    assert sku
+    product_url = sku.product.url
+    if product_url:
+        sku_url = make_sku_url(sku.code, product_url)
+    else:
+        sku_url = None
+    return _templates.TemplateResponse(
+        "sku.html", {"request": request, "sku": sku, "sku_url": sku_url}
     )

--- a/src/canadiantracker/model.py
+++ b/src/canadiantracker/model.py
@@ -1,4 +1,6 @@
+from __future__ import annotations
 import datetime
+from typing import Iterable
 
 
 class ProductInfo:
@@ -7,20 +9,20 @@ class ProductInfo:
         self._raw_payload = result
 
     @property
-    def price(self) -> float:
-        try:
-            price = self._raw_payload["Promo"]["Price"]
-        except KeyError:
-            price = self._raw_payload["Price"]
-        return float(price)
+    def price(self) -> float | None:
+        current_price = self._raw_payload["currentPrice"]
+        if current_price is None:
+            return None
+
+        return float(current_price["value"])
 
     @property
     def code(self) -> str:
-        return self._raw_payload["Product"]
+        return self._raw_payload["code"]
 
     @property
     def in_promo(self) -> bool:
-        return "Promo" in self._raw_payload
+        return self._raw_payload["priceValidUntil"] is not None
 
     @property
     def raw_payload(self) -> str:
@@ -31,12 +33,14 @@ class ProductInfo:
 
 
 class ProductListingEntry:
-    def __init__(self, code: str, name: str, is_in_clearance: bool, url: str, sku: str):
+    def __init__(
+        self, code: str, name: str, is_in_clearance: bool, url: str, skus: list[Sku]
+    ):
         self._code = code
         self._name = name
         self._is_in_clearance = is_in_clearance
         self._url = url
-        self._sku = sku
+        self._skus = skus
 
     def __str__(self) -> str:
         return "[{code}] {name}".format(code=self._code, name=self._name)
@@ -58,8 +62,8 @@ class ProductListingEntry:
         return self._url
 
     @property
-    def sku(self) -> str:
-        return self._sku
+    def skus(self) -> Iterable[Sku]:
+        return self._skus
 
     def __repr__(self):
         props = {
@@ -68,6 +72,20 @@ class ProductListingEntry:
             "is_in_clearance": self._is_in_clearance,
         }
         return str(props)
+
+
+class Sku:
+    def __init__(self, code: str, formatted_code: str):
+        self._code = code
+        self._formatted_code = formatted_code
+
+    @property
+    def code(self) -> str:
+        return self._code
+
+    @property
+    def formatted_code(self) -> str:
+        return self._formatted_code
 
 
 class ProductInfoSample:

--- a/src/canadiantracker/storage.py
+++ b/src/canadiantracker/storage.py
@@ -271,7 +271,7 @@ class _SQLite3ProductRepository(ProductRepository):
                 logger.debug("Updating URL of existing product")
                 entry.url = product_listing_entry.url
 
-        # Get existing SKU codes for that products, to determine which SKUs
+        # Get existing SKU codes for that product, to determine which SKUs
         # are new.
         existing_sku_codes = set()
         for sku in entry.skus:
@@ -292,7 +292,7 @@ class _SQLite3ProductRepository(ProductRepository):
         self, product_infos: Iterator[canadiantracker.model.ProductInfo]
     ) -> None:
         for info in product_infos:
-            # Some responses have null as the current proce.
+            # Some responses have null as the current price.
             price = info.price
             if price is None:
                 continue

--- a/src/canadiantracker/storage.py
+++ b/src/canadiantracker/storage.py
@@ -283,7 +283,20 @@ class _SQLite3ProductRepository(ProductRepository):
                 continue
 
             logger.debug(f"  SKU {sku.code} not present in storage, adding")
-            _StorageSku(sku.code, sku.formatted_code, entry)
+            stored_sku = self.get_sku_by_code(sku.code)
+            if stored_sku:
+                # A sku with this code already exists, but it is
+                # associated with a different product. These kind of "migrations"
+                # happen periodically when a sku is re-parented to a different
+                # product (typically because it changed names). In this case,
+                # edit the existing entry.
+                logger.debug(
+                    f"  SKU {sku.code} is associated to a different product: previous product was '{stored_sku.product.name} ({stored_sku.product.code})', new product is '{entry.name} ({entry.code})'"
+                )
+                stored_sku.entry = entry
+            else:
+                # Create a new sku entry.
+                _StorageSku(sku.code, sku.formatted_code, entry)
 
         if add_entry:
             self._session.add(entry)

--- a/src/canadiantracker/triangle.py
+++ b/src/canadiantracker/triangle.py
@@ -1,162 +1,218 @@
-from typing import Generator
+from __future__ import annotations
+from datetime import datetime
+from typing import Callable, Generator, Tuple
 import requests
 import logging
 import fake_useragent
+import time
 from collections.abc import Sequence, Iterable, Iterator
 
-from canadiantracker.model import ProductListingEntry, ProductInfo
+from canadiantracker.model import ProductListingEntry, ProductInfo, Sku
 
 logger = logging.getLogger(__name__)
 
 
 class _ProductCategory:
-    def __init__(self, name: str, pretty_name: str):
+    def __init__(self, id: str, name: str, subcategories: list[_ProductCategory]):
+        self._id = id
         self._name = name
-        self._pretty_name = pretty_name
-        self._num_levels = len(name.split("::"))
+        self._subcategories = subcategories
+        self._parent = None
+
+        for sub in self._subcategories:
+            sub._parent = self
+
+    @property
+    def id(self) -> str:
+        return self._id
 
     @property
     def name(self) -> str:
         return self._name
 
     @property
-    def pretty_name(self) -> str:
-        return self._pretty_name
+    def full_name(self) -> str:
+        if self._parent:
+            return f"{self._parent.full_name} > {self.name}"
+        else:
+            return self.name
 
     @property
-    def num_levels(self) -> int:
-        """Number of levels in the category."""
-        return self._num_levels
+    def subcategories(self) -> list[_ProductCategory]:
+        return self._subcategories
+
+    def visit(
+        self, callback: Callable[[_ProductCategory, int], None], level: int
+    ) -> None:
+        callback(self, level)
+        for sub in self.subcategories:
+            sub.visit(callback, level + 1)
+
+    def iter_preorder(
+        self, level: int
+    ) -> Generator[Tuple[_ProductCategory, int], None, None]:
+        yield self, level
+        for cat in self.subcategories:
+            yield from cat.iter_preorder(level + 1)
+
+
+class _ProductCategories:
+    def __init__(self, categories: list[_ProductCategory]):
+        self._categories = categories
+
+    def visit(self, callback: Callable[[_ProductCategory, int], None]) -> None:
+        for sub in self._categories:
+            sub.visit(callback, 1)
+
+    def iter_preorder(self) -> None:
+        """Iterate on the category tree, in pre-order."""
+        for cat in self._categories:
+            yield from cat.iter_preorder(1)
+
+    @property
+    def categories(self) -> Iterable[_ProductCategory]:
+        return self._categories
+
+
+_base_headers = {
+    "authority": "apim.canadiantire.ca",
+    "accept": "application/json, text/plain, */*",
+    "accept-language": "en-US,en;q=0.9",
+    "bannerid": "CTR",
+    "basesiteid": "CTR",
+    "ocp-apim-subscription-key": "c01ef3612328420c9f5cd9277e815a0e",
+    "origin": "https://www.canadiantire.ca",
+    "referer": "https://www.canadiantire.ca/",
+    "sec-ch-ua": '" Not A;Brand";v="99", "Chromium";v="102", "Google Chrome";v="102"',
+    "sec-ch-ua-mobile": "?0",
+    "sec-ch-ua-platform": '"Windows"',
+    "sec-fetch-dest": "empty",
+    "sec-fetch-mode": "cors",
+    "sec-fetch-site": "same-site",
+    "service-client": "ctr/web",
+    "service-version": "ctc-dev2",
+    "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.0.0 Safari/537.36",
+    "x-web-host": "www.canadiantire.ca",
+    "cache-control": "no-cache",
+    "pragma": "no-cache",
+}
 
 
 class ProductInventory(Iterable):
     def __init__(
-        self, dev_max_categories: int = 0, dev_max_pages_per_category: int = 0
+        self,
+        category_levels_to_scrape: list[int] = None,
+        dev_max_categories: int = 0,
+        dev_max_pages_per_category: int = 0,
     ):
         self._dev_max_pages_per_category = dev_max_pages_per_category
-        response = ProductInventory._request_page().json()
-        self._total_unique_products = int(response["query"]["total-results"])
-        logger.debug(
-            "API returned %i unique products to list", self._total_unique_products
-        )
-        self._total_products_to_list = 0
-
-        self._product_categories = []
-        for name, pretty_name in response["metadata"]["categoryMap"].items():
-            # The Triangle product listing API seems to have an internal limit
-            # that prevents listing more than ~10,000 items. To work around this,
-            # we list products by category.
-            #
-            # Categories are hierarchical, for example: automotive,
-            # automotive::car-cleaning. Overall, most products seem to belong to
-            # a sub-category and to the higher-level categories that contain that
-            # category.
-            #
-            # However, it seems some products can belong to the top-level
-            # category exclusively. When that top-level category contains more
-            # than ~10,000 items, we risk not being able to list some products
-            # at all (albeit very few).
-            #
-            # Limiting ourselves to level 1 and 2 categories appears to allow
-            # us to list most products while also limiting the number of products
-            # re-listed for nothing.
-            cat = _ProductCategory(name, pretty_name)
-            if cat.num_levels == 1 or cat.num_levels == 2:
-                self._product_categories.append(cat)
-
-                if (
-                    dev_max_categories != 0
-                    and len(self._product_categories) == dev_max_categories
-                ):
-                    break
-
-        # This takes a fair amount of time (1 request per category) just to have
-        # an accurate number of items fed to the progress bar...
+        self._dev_max_categories = dev_max_categories
+        # The Triangle product listing API seems to have an internal limit
+        # that prevents listing more than ~10,000 items. To work around this,
+        # we list products by category.
         #
-        # In the grand scheme of things it doesn't matter much, but this
-        # should probably be made optional.
-        self._product_categories.sort(key=lambda category: category.name)
-        for c in self._product_categories:
-            response = ProductInventory._request_page(c).json()
-            count = int(response["query"]["total-results"])
-            logger.debug(
-                "Product category %s (%s): %i products", c.name, c.pretty_name, count
-            )
-            self._total_products_to_list = self._total_products_to_list + count
+        # Categories are hierarchical, for example: automotive,
+        # automotive::car-cleaning. Overall, most products seem to belong to
+        # a sub-category and to the higher-level categories that contain that
+        # category.
+        #
+        # However, we have seen illogical results, where scraping, say, all level 2
+        # categories under automotive, we found more products than by just scraping
+        # automotive.  There is therefore some value in scraping all categories, at
+        # all levels.  But it would be very expensive to do this every day.  There
+        # are 5 levels of categories at the time of writing, so scraping all levels
+        # would mean scraping 5 times the number of products.  To find a good
+        # balance, the default is to scrape one category level, based on the number
+        # of the day.  Note that this is only to discover new products, so at worst
+        # it will take a few more days to discover a new product that only appears
+        # in a specific category level, for some reason.
+        self._categories = self._fetch_categories()
+        max_level = 0
+        for cat, level in self._categories.iter_preorder():
+            logger.debug(f"[{level}] {cat.id} - {cat.full_name}")
+            max_level = max(level, max_level)
 
-        logger.debug(
-            "%i products will be listed (with duplicates)", self._total_products_to_list
+        if category_levels_to_scrape is None:
+            # No category level specified.  Choose one based on the current day.
+            self._category_levels_to_scrape = [datetime.now().day % max_level + 1]
+        else:
+            self._category_levels_to_scrape = category_levels_to_scrape
+
+        logger.debug(f"Category levels to scrape: {self._category_levels_to_scrape}")
+
+    def _fetch_categories(self) -> _ProductCategories:
+        """Fetch the list of categories, create some objects out of it."""
+        response = requests.get(
+            "https://apim.canadiantire.ca/v1/category/api/v1/categories",
+            headers=_base_headers,
+            params={"lang": "en_CA"},
         )
+
+        if response.status_code != 200:
+            logger.error(response.text)
+            raise RuntimeError("Failed to get category list")
+
+        def _handle_categories(raw: list[dict]) -> list[_ProductCategory]:
+            def _handle_one_category(raw: dict) -> _ProductCategory:
+                subcats = _handle_categories(raw["subcategories"])
+                return _ProductCategory(raw["id"], raw["name"], subcats)
+
+            cats = []
+            for c in raw:
+                cats.append(_handle_one_category(c))
+            cats.sort(key=lambda category: category.name)
+            return cats
+
+        categories = _handle_categories(response.json()["categories"])
+        return _ProductCategories(categories)
 
     @staticmethod
-    def _request_page(category: _ProductCategory = None, page_number: int = 1) -> dict:
-        url = "https://api.canadiantire.ca/search/api/v0/product/en/"
-        headers = {
-            "Accept": "*/*",
-            "Accept-Encoding": "gzip, deflate",
-            "Connection": "keep-alive",
-            "Host": "api.canadiantire.ca",
-        }
-
-        params = {"site": "ct", "page": page_number, "format": "json"}
-
-        if category:
-            params["x1"] = f"ast-id-level-{category.num_levels}"
-            params["q1"] = category.name
-
+    def _request_page(
+        cat: _ProductCategory, cat_level: int, page_number: int = 1
+    ) -> requests.Response:
+        """Fetch one page of products."""
         return requests.get(
-            url,
-            headers=headers,
-            params=params,
+            f"https://apim.canadiantire.ca/v1/search/search?store=64&lang=en_CA&x1=ast-id-level-{cat_level}&q1={cat.id}&experience=category;count=48;page={page_number}",
+            headers=_base_headers,
         )
 
-    # Name of the category currently being iterated on.
-    @property
-    def current_iteration_category_name(self) -> str:
-        return self._currentCategory.pretty_name if self._currentCategory else None
-
-    def __len__(self) -> int:
-        return self._total_products_to_list
-
     def __iter__(self) -> Iterator[ProductListingEntry]:
-        logger.debug("Starting enumaration of %i products", len(self))
+        num_categories_scraped = 0
 
-        for category in self._product_categories:
+        for cat, level in self._categories.iter_preorder():
+            if level not in self._category_levels_to_scrape:
+                continue
+
+            num_categories_scraped += 1
+
+            logger.debug(f"Starting category {cat.full_name}")
             page = 1
+            num_pages = None
 
-            iterated_in_category = 0
-            to_iterate_in_category = None
-            self._currentCategory = category
-
-            while (
-                to_iterate_in_category is None
-                or iterated_in_category < to_iterate_in_category
-            ):
-                response = ProductInventory._request_page(
-                    category, page_number=page
-                ).json()
-
-                if to_iterate_in_category is None:
-                    to_iterate_in_category = int(response["query"]["total-results"])
-
+            while num_pages is None or page < (num_pages + 1):
                 logger.debug(
-                    "Fetching listing of category {} (page {}, {}/{})".format(
-                        category.pretty_name,
-                        page,
-                        iterated_in_category,
-                        to_iterate_in_category,
-                    )
+                    f"Fetching listing of category {cat.full_name} (page {page}/{num_pages})"
                 )
+                response = ProductInventory._request_page(cat, level, page_number=page)
+                response = response.json()
 
-                for product in response["results"]:
-                    iterated_in_category = iterated_in_category + 1
-                    yield ProductListingEntry(
-                        product["field"]["prod-id"],
-                        product["field"]["prod-name"],
-                        product["field"]["clearance"] == "T",
-                        product["field"]["pdp-url"],
-                        product["field"]["sku-number"],
-                    )
+                if num_pages is None:
+                    num_pages = int(response["pagination"]["total"])
+
+                for product in response["products"]:
+                    assert product["type"] == "PRODUCT"
+
+                    skus = []
+                    for sku in product["skus"]:
+                        code = sku["code"]
+                        formatted_code = sku["formattedCode"]
+                        skus.append(Sku(code, formatted_code))
+
+                    code = product["code"]
+                    url = product["url"]
+                    name = product["title"]
+                    is_in_clearance = "CLEARANCE" in product["badges"]
+                    yield ProductListingEntry(code, name, is_in_clearance, url, skus)
 
                 if (
                     self._dev_max_pages_per_category != 0
@@ -166,14 +222,20 @@ class ProductInventory(Iterable):
 
                 page = page + 1
 
+            if (
+                self._dev_max_categories != 0
+                and self._dev_max_categories == num_categories_scraped
+            ):
+                break
+
 
 class ProductLedger(Iterable):
-    def __init__(self, products: Iterator[ProductListingEntry]):
-        self._products = products
+    def __init__(self, skus: Iterator[Sku]):
+        self._skus = skus
         pass
 
     def __len__(self) -> int:
-        return len(self._products)
+        return len(self._skus)
 
     @staticmethod
     def _batches(it: Iterator, batch_max_size: int) -> Generator[list, None, None]:
@@ -193,31 +255,46 @@ class ProductLedger(Iterable):
 
     @staticmethod
     def _get_product_infos(
-        productListings: Sequence[ProductListingEntry],
+        skus: Sequence[Sku],
     ) -> Sequence[ProductInfo]:
-        url = "https://api-triangle.canadiantire.ca/esb/PriceAvailability"
-        headers = {
-            "Accept": "*/*",
-            "Accept-Encoding": "gzip, deflate",
-            "Connection": "keep-alive",
-            "Host": "api-triangle.canadiantire.ca",
-            "User-Agent": ProductLedger._user_agent(),
-        }
+        for ntry in range(5):
+            url = "https://apim.canadiantire.ca/v1/product/api/v1/product/sku/PriceAvailability/?lang=en_CA&storeId=64"
+            headers = _base_headers.copy()
+            headers["user-agent"] = ProductLedger._user_agent()
+            headers["content-type"] = "application/json"
 
-        params = {
-            "Product": ",".join([product.code for product in productListings]),
-            "Banner": "CTR",
-            "Language": "E",
-        }
+            body = {
+                "skus": [
+                    {
+                        "code": sku.code,
+                        "lowStockThreshold": 0,
+                    }
+                    for sku in skus
+                ]
+            }
 
-        logger.debug("requested {} product infos".format(len(productListings)))
-        response = requests.get(url, headers=headers, params=params)
-        logger.debug("received {} product infos".format(len(response.json())))
-        logger.debug(str(response.json()))
-        return [ProductInfo(product_info) for product_info in response.json()]
+            logger.debug("requested {} product infos".format(len(skus)))
+            response = requests.post(url, headers=headers, json=body)
+
+            if response.status_code != 200:
+                # Wait a bit before retrying, in case the admin is restarting the container.
+                logger.error(f"Got status code {response.status_code} on try {ntry}")
+                time.sleep(5)
+                continue
+
+            with open("/tmp/res", "w") as f:
+                f.write(response.text)
+
+            response = response.json()
+            response_skus = response["skus"]
+            logger.debug("received {} product infos".format(len(response_skus)))
+
+            return [ProductInfo(product_info) for product_info in response_skus]
+
+        raise RuntimeError("Failed to get product info")
 
     def __iter__(self) -> Iterator[ProductInfo]:
-        # The API limits requests to 40 products
-        for batch in self._batches(self._products, 40):
+        # The API limits requests to 50 products
+        for batch in self._batches(self._skus, 50):
             for product_info in self._get_product_infos(batch):
                 yield product_info

--- a/src/canadiantracker/web/templates/product.html
+++ b/src/canadiantracker/web/templates/product.html
@@ -3,59 +3,21 @@
 
 <head>
     {% include 'libs.html' %}
-
-    <script>
-        $(document).ready(function () {
-            const code = $('body').attr('data-product-code');
-            $.get('/api/products/' + code + '/samples').done(samples => {
-                const xs = [];
-                const ys = [];
-
-                let i = 0;
-                let last_price = 0;
-                for (const sample of samples) {
-                    time = sample.sample_time;
-                    price = sample.product_info.price;
-
-                    /* Insert the last price to render changes as "steps". */
-                    if (i && price != last_price) {
-                        xs.push(time);
-                        ys.push(last_price)
-                    }
-
-                    xs.push(time);
-                    ys.push(price);
-                    last_price = price;
-                    i++;
-                }
-
-                const div = $('#price-history')[0];
-                Plotly.newPlot(div, [{
-                    x: xs,
-                    y: ys,
-                    type: 'scatter',
-                    mode: 'lines',
-                }], {
-                    yaxis: {
-                        rangemode: 'tozero',
-                    },
-                }
-                );
-            });
-
-        });
-    </script>
-    <title>CanadianTracker - {{ listing.name }}</title>
+    <title>CanadianTracker - {{ product.name }}</title>
 </head>
 
-<body data-product-code="{{ listing.code }}">
+<body>
     <p>
-        Name: {{ listing.name }}
+        Name: {{ product.name }}
         <br>
-        <a href="https://canadiantire.ca{{ listing.url }}">{{ listing.sku }}</a>
+        <a href="https://canadiantire.ca{{ product.url }}">{{ product.code }}</a>
     </p>
 
-    <div id="price-history" style="width:600px;height:250px;"></div>
+    <ul>
+        {% for sku in product.skus %}
+            <li><a href="/skus/{{ sku.code }}">{{ sku.formatted_code }}</a></li>
+        {% endfor %}
+    </ul>
 </body>
 
 </html>

--- a/src/canadiantracker/web/templates/sku.html
+++ b/src/canadiantracker/web/templates/sku.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    {% include 'libs.html' %}
+
+    <script>
+        $(document).ready(function () {
+            const code = $('body').attr('data-sku-code');
+            $.get('/api/skus/' + code + '/samples').done(samples => {
+                const xs = [];
+                const ys = [];
+
+                let i = 0;
+                let last_price = 0;
+                for (const sample of samples) {
+                    time = sample.sample_time;
+                    price = sample.product_info.price;
+
+                    /* Insert the last price to render changes as "steps". */
+                    if (i && price != last_price) {
+                        xs.push(time);
+                        ys.push(last_price)
+                    }
+
+                    xs.push(time);
+                    ys.push(price);
+                    last_price = price;
+                    i++;
+                }
+
+                const div = $('#price-history')[0];
+                Plotly.newPlot(div, [{
+                    x: xs,
+                    y: ys,
+                    type: 'scatter',
+                    mode: 'lines+markers',
+                }], {
+                    yaxis: {
+                        rangemode: 'tozero',
+                    },
+                }
+                );
+            });
+
+        });
+    </script>
+    <title>CanadianTracker - {{ sku.product.name }}</title>
+</head>
+
+<body data-sku-code="{{ sku.code }}">
+    <p>
+        Name: {{ sku.product.name }}
+        <br>
+        <a href="https://canadiantire.ca{{ sku_url }}">{{ sku.formatted_code }}</a>
+    </p>
+
+    <div id="price-history" style="width:600px;height:250px;"></div>
+</body>
+
+</html>


### PR DESCRIPTION
We currently don't handle multi-SKU products well, fix that.

TLDR:

 - Add database table for SKUs
 - Use newer API to be able to get more details about SKUs
 - Adjust web UI to account for that

Taking this product as an example:

https://www.canadiantire.ca/en/pdp/thule-convoy-xt-rooftop-cargo-box-0401588p.html

This product has 3 different variants, or SKUs, with three different
prices.  There is a single entry in the products_static table.  The
`sku` columns contains a list of all the three SKUs for that product:

  40-1588-0|40-1589-8|40-1590-2

In the products_dynamic table, the samples for multi-SKU products refer
to the complete product, not a specific SKU.  For the example product,
we have samples like this one:

    {
        "Banner": "CTR",
        "Product": "0401588P",
        "PrimarySKU": "0401588",
        "CheckDigit": "0",
        "SKU_Count": 3,
        "Price": 699.99,
        "PriceFrom": "Y",
        "Description": "THL ALP 12CFT CNV XT",
        "Messages": {
            "Warranty": "This product carries a 1 year exchange warranty redeemable at any Canadian Tire store."
        },
        "PartNumber": "632100",
        "IsOnline": {
            "Active": "Y",
            "Exclusive": "N",
            "Sellable": "Y",
            "SpecialBuy": "N"
        }
    }

Note "PriceFrom" is "Y".  I believe this means that the rendered product
list would say "From $699.99", meaning that $699.99 is the price of one
of the three SKUs, we don't know which one (whichever is the
cheapest).  Given that we want to track prices for each individual SKU,
samples like this one are not helpful, and will have to be discarded.

Samples that refer to a single-SKU product have a `SKU` key, so we can
be confident the price is for a specific SKU.

Changes at the database level:

  - add the `skus` table, with the following columns:
    - index: auto-incremented integer
    - code: code, in the format "0401589"
    - formatted_code: code, in the format "040-1589-8"
    - product_index: index of the product (products_static table) this
      SKU belongs to
  - remove the `skus` column of the `products_static` table.
  - add the `samples` table, which is like the existing
    `products_dynamic` table, but with a foreign reference to the `skus`
    table, instead of to the `products_static` table .
  - remove the `products_dynamic` table.

The migration does the following steps to keep as much of the existing
data as possible:

  - Populate the `skus` table based on the existing content of the `sku`
    column of the `products_static` table, whose format is shown above.
  - Go over each existing price sample (`products_dynamic` table), see
    if we can move it to the new table.  If it doesn't have a `SKU` key,
    or has 'PriceFrom: Y' (I think these two are correlated, but we
    check both just in case), we can't.  Use the `SKU` value to know
    which row in the `skus` table this sample will now refer to.
  - There are some products without SKU information in column
    `products_static.sku`.  This is probably because these products were
    not seen since we added the `sku` column.  For those, we did not
    create an entry in the `skus` table.  If some samples refer to that
    SKU, we have a problem.  In that case, create a `skus` row based on
    that SKU number.  Assume that the product code is the SKU code plus
    'P', which always seems to be the case for single-SKU products.
    There are some rare cases where there is no such product, in that
    case we drop the sample.

Adjust the scraping code to provide this new information.  To do so, use
newer APIs, which are those I see the Canadian Tire website use at the
time of writing.  In the new API used for fetching list of products, the
information about SKUs is better structured than in the previous one.

We previously limited ourselves to scraping the categories of level 1
and 2.  During my testing, I saw that scraping each level of category
gave a different number of items, and there always seemed to be items
that appeared only in one level and not the others.  To have the best
coverage, we would have to scrape all category levels.  But doing so
would increase the workload quite a bit, if done each day.  The tradeoff
I made to have good coverage but not a huge workload is to use one
category level each day.  The category level is based on the number of
the current day, so if the scraping is done every day (which is the case
in our production system), we'll do all category levels in a round robin
fashion.  This step is to discover new products/skus, so it's fine if we
don't discover a new one immediately.  This is only the default though,
the category levels to scrape can be specified on the command-line.

I removed the step where we fetch the number of items in each category
to provide a length to ProductLedger.  When scraping the level 5 (the
most specific categories), this is just too long, since there are
hundreds of categories.  As a consequence, we no longer show a progress
bar with a known length when scraping the inventory.  We could maybe add
it back later, and make it optional.

Adjust the web UI to add a "SKU" page.  So, the user lands on the index,
which is the list of products.  The user clicks on a product, they land
on the list of SKUs for that product.  They then click on the SKU they
want.  The experience sucks, it will have to be improved, but it works.
The existing product.html page becomes sku.html, with minor obvious
changes (but git won't tell you that).

Adjust the ctquery command accordingly.