### PR TITLE
Create index on samples.sku_index

### DIFF
--- a/alembic/versions/d3f6991d4671_add_index_to_samples.py
+++ b/alembic/versions/d3f6991d4671_add_index_to_samples.py
@@ -1,0 +1,24 @@
+"""add index to samples
+
+Revision ID: d3f6991d4671
+Revises: 9169a7c5bda3
+Create Date: 2022-08-14 22:59:38.685376
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "d3f6991d4671"
+down_revision = "9169a7c5bda3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(None, "samples", ["sku_index"])
+
+
+def downgrade():
+    pass

--- a/src/canadiantracker/storage.py
+++ b/src/canadiantracker/storage.py
@@ -172,7 +172,7 @@ class InvalidDatabaseRevisionException(Exception):
 
 
 class _SQLite3ProductRepository(ProductRepository):
-    ALEMBIC_REVISION = "9169a7c5bda3"
+    ALEMBIC_REVISION = "d3f6991d4671"
 
     def __init__(self, path: str):
         db_url = "sqlite:///" + os.path.abspath(path)


### PR DESCRIPTION
Looking up for samples belonging to a sku index (as is the case when
looking at a sku page on the web UI) is very slow.  Create an index to
remedy that.