### PR TITLE
Update name and URL when trying to add existing product

### DIFF
--- a/src/canadiantracker/storage.py
+++ b/src/canadiantracker/storage.py
@@ -264,12 +264,18 @@ class _SQLite3ProductRepository(ProductRepository):
             add_entry = False
 
             # update last listed time
-            setattr(entry, "last_listed", datetime.datetime.now())
+            entry.last_listed = datetime.datetime.now()
 
-            # If the URL is NULL, set it.
-            if entry.url is None:
-                logger.debug("Updating URL of existing product")
+            # Update URL, name and "in clearance" status, these can change over
+            # time.
+            if entry.url != product_listing_entry.url:
                 entry.url = product_listing_entry.url
+
+            if entry.name != product_listing_entry.name:
+                entry.name = product_listing_entry.name
+
+            if entry.is_in_clearance != product_listing_entry.is_in_clearance:
+                entry.is_in_clearance = product_listing_entry.is_in_clearance
 
         # Get existing SKU codes for that product, to determine which SKUs
         # are new.


### PR DESCRIPTION
Product names and URLs are susceptible to change, notably when a
multi-variant product gets split and the original product becomes a
specific variant.  Update them when trying to add a product that already
exists.

Update the is_in_clearance flag as well, since we want to know when a
product becomes in clearance.