### PR TITLE
Cache response of /api/products endpoint

### DIFF
--- a/src/canadiantracker/http.py
+++ b/src/canadiantracker/http.py
@@ -1,6 +1,7 @@
 import os
+import json
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, Response
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
@@ -13,19 +14,32 @@ _templates = Jinja2Templates(directory=os.path.dirname(__file__) + "/web/templat
 _repository = canadiantracker.storage.get_product_repository_from_sqlite_file(_db_path)
 
 
-@app.get("/api/products")
-async def api_products() -> list[dict]:
-    ret = []
+# This request takes a few seconds to execute, causing some delay when
+# accessing the products page.  Since the contents of the database never
+# changes while we're running, cache the returned Response object.
+cached_products_response = None
 
-    for p in _repository.products:
-        ret.append(
-            {
-                "name": p.name,
-                "code": p.code,
-            }
+
+@app.get("/api/products")
+async def api_products() -> Response:
+    global cached_products_response
+
+    if cached_products_response is None:
+        products = []
+
+        for p in _repository.products:
+            products.append(
+                {
+                    "name": p.name,
+                    "code": p.code,
+                }
+            )
+
+        cached_products_response = Response(
+            json.dumps(products), media_type="application/json"
         )
 
-    return ret
+    return cached_products_response
 
 
 def serialize_product_info(info: ProductInfo) -> dict:


### PR DESCRIPTION
With the current production CanadianTracker server (a very modest VPS),
it takes me more than 9 seconds from starting to load the page until we
see the filled products table.  Using the Firefox profiler, I see that
the breakdown of that time is roughly:

 - Load the page / initialial request: 0.7 s
 - Load the assets (.css, .js), parse and execute the JS: 0.7 s
 - Datatables fetching /api/products: 5.8 s
 - Datatables rendering the contents of the table: 2.3 s

Of course, there are a lot of variations, this is just one run.

A good portion of fetching /api/products is reading the data from the
database (more than 100k products), filling the Python data structures
and serializing them to JSON.  Since the database contents never changes
while the web application is running (it is restarted to load a new
database), we can cache the response and always return the same prepared
response.  This is what this patch implements.  We prepare a response
object (as documented here [1]) and cache it, returning it on subsequent
requests.

I initially tried to use fastapi-cache [2], but that did not let me
cache the finished response.  We could cache the returned Python list,
but the json serialization would unnecessarily be done on every request
by Fastapi.  So I opted for the simple solution implemented here.

With this change, I see a load time of about 3 seconds in total (once
the cache is hot).

 - Load the page / initialial request: 0.5 s
 - Load the assets (.css, .js), parse and execute the JS: 0.5 s
 - Datatables fetching /api/products: 0.7 s
 - Datatables rendering the contents of the table: 2.3 s

We could reduce the initial load time by using server-side processing.
This way, we would only load one page of products a a time, and
Datatables would offload filtering and sorting to the server.  But I
think that would reduce overall snappiness (client-side filtering and
sorting is very snappy, even with that many rows), so that wouldn't
really be an improvement.

[1] https://fastapi.tiangolo.com/advanced/response-directly/
[2] https://github.com/long2ice/fastapi-cache