### PR TITLE
Fix: scraper: commit current transaction before vacuuming

### DIFF
--- a/src/canadiantracker/storage.py
+++ b/src/canadiantracker/storage.py
@@ -263,6 +263,14 @@ class _SQLite3ProductRepository(ProductRepository):
         self._session.flush()
 
     def vacuum(self):
+        # Vacuum can't be run during a transaction; complete the current
+        # transaction before vacuuming.
+        #
+        # FIXME This may be a bit surprising, should the API ask that users
+        # commit explicitly (adding a new method) to make sure they are aware
+        # of the risks? 😏
+        if self._session.in_transaction():
+            self._session.commit()
         self._session.execute("VACUUM")
 
     def get_product_listing_by_code(


### PR DESCRIPTION
The vacuum command cannot be used during a transaction. An exception is currently thrown whenever a vacuum is attempted after removing samples.

Traceback (most recent call last):
  File "/home/jgalar/.cache/pypoetry/virtualenvs/canadiantracker-p8QAoAzB-py3.10/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1802, in _execute_context
    self.dialect.do_execute(
  File "/home/jgalar/.cache/pypoetry/virtualenvs/canadiantracker-p8QAoAzB-py3.10/lib/python3.10/site-packages/sqlalchemy/engine/default.py", line 732, in do_execute
    cursor.execute(statement, parameters)
sqlite3.OperationalError: cannot VACUUM from within a transaction

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/jgalar/.cache/pypoetry/virtualenvs/canadiantracker-p8QAoAzB-py3.10/lib/python3.10/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/home/jgalar/.cache/pypoetry/virtualenvs/canadiantracker-p8QAoAzB-py3.10/lib/python3.10/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/home/jgalar/.cache/pypoetry/virtualenvs/canadiantracker-p8QAoAzB-py3.10/lib/python3.10/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/jgalar/.cache/pypoetry/virtualenvs/canadiantracker-p8QAoAzB-py3.10/lib/python3.10/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/jgalar/.cache/pypoetry/virtualenvs/canadiantracker-p8QAoAzB-py3.10/lib/python3.10/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/home/jgalar/Projects/CanadianTracker/src/canadiantracker/scraper.py", line 272, in prune_samples
    repository.vacuum()
  File "/home/jgalar/Projects/CanadianTracker/src/canadiantracker/storage.py", line 267, in vacuum
    self._session.execute("VACUUM")
  File "/home/jgalar/.cache/pypoetry/virtualenvs/canadiantracker-p8QAoAzB-py3.10/lib/python3.10/site-packages/sqlalchemy/orm/session.py", line 1692, in execute
    result = conn._execute_20(statement, params or {}, execution_options)
  File "/home/jgalar/.cache/pypoetry/virtualenvs/canadiantracker-p8QAoAzB-py3.10/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1614, in _execute_20
    return meth(self, args_10style, kwargs_10style, execution_options)
  File "/home/jgalar/.cache/pypoetry/virtualenvs/canadiantracker-p8QAoAzB-py3.10/lib/python3.10/site-packages/sqlalchemy/sql/elements.py", line 325, in _execute_on_connection
    return connection._execute_clauseelement(
  File "/home/jgalar/.cache/pypoetry/virtualenvs/canadiantracker-p8QAoAzB-py3.10/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1481, in _execute_clauseelement
    ret = self._execute_context(
  File "/home/jgalar/.cache/pypoetry/virtualenvs/canadiantracker-p8QAoAzB-py3.10/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1845, in _execute_context
    self._handle_dbapi_exception(
  File "/home/jgalar/.cache/pypoetry/virtualenvs/canadiantracker-p8QAoAzB-py3.10/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 2026, in _handle_dbapi_exception
    util.raise_(
  File "/home/jgalar/.cache/pypoetry/virtualenvs/canadiantracker-p8QAoAzB-py3.10/lib/python3.10/site-packages/sqlalchemy/util/compat.py", line 207, in raise_
    raise exception
  File "/home/jgalar/.cache/pypoetry/virtualenvs/canadiantracker-p8QAoAzB-py3.10/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1802, in _execute_context
    self.dialect.do_execute(
  File "/home/jgalar/.cache/pypoetry/virtualenvs/canadiantracker-p8QAoAzB-py3.10/lib/python3.10/site-packages/sqlalchemy/engine/default.py", line 732, in do_execute
    cursor.execute(statement, parameters)
sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) cannot VACUUM from within a transaction

Signed-off-by: Jérémie Galarneau <jeremie.galarneau@gmail.com>