### PR TITLE
Change type of samples price column to integer

### DIFF
--- a/alembic/versions/ac8256c291d4_change_price_column_type_to_int.py
+++ b/alembic/versions/ac8256c291d4_change_price_column_type_to_int.py
@@ -1,0 +1,37 @@
+"""change price column type to int
+
+Revision ID: ac8256c291d4
+Revises: d3f6991d4671
+Create Date: 2022-10-07 21:16:06.677110
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "ac8256c291d4"
+down_revision = "d3f6991d4671"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    db = op.get_bind()
+    metadata = sa.MetaData()
+    samples_table = sa.Table("samples", metadata, autoload_with=op.get_bind().engine)
+
+    print(">>> Adding price_cents column")
+    op.add_column("samples", sa.Column("price_cents", sa.Integer(), nullable=True))
+    print(">>> Filling price_cents column")
+    db.execute("UPDATE samples SET price_cents = 100 * price")
+
+    with op.batch_alter_table("samples") as batch_op:
+        print(">>> Marking price_cents column non-nullable")
+        batch_op.alter_column("price_cents", nullable=False)
+        print(">>> Dropping price column")
+        batch_op.drop_column("price")
+
+
+def downgrade():
+    pass

--- a/src/canadiantracker/model.py
+++ b/src/canadiantracker/model.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import datetime
+import decimal
 from typing import Iterable
 
 
@@ -9,12 +10,14 @@ class ProductInfo:
         self._raw_payload = result
 
     @property
-    def price(self) -> float | None:
+    def price(self) -> decimal.Decimal | None:
         current_price = self._raw_payload["currentPrice"]
         if current_price is None:
             return None
 
-        return float(current_price["value"])
+        value = current_price["value"]
+        assert type(value) is decimal.Decimal
+        return value
 
     @property
     def code(self) -> str:

--- a/src/canadiantracker/triangle.py
+++ b/src/canadiantracker/triangle.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from datetime import datetime
+import decimal
 from typing import Callable, Generator, Tuple
 import requests
 import logging
@@ -285,7 +286,7 @@ class ProductLedger(Iterable):
             with open("/tmp/res", "w") as f:
                 f.write(response.text)
 
-            response = response.json()
+            response = response.json(parse_float=decimal.Decimal)
             response_skus = response["skus"]
             logger.debug("received {} product infos".format(len(response_skus)))
 


### PR DESCRIPTION
When querying the database from Python/SQLAlchemy, we get this warning:

    $ poetry run ctquery price-history --db-path inventory.db 027-8158-6
    /home/simark/src/CanadianTracker/src/canadiantracker/query.py:123: SAWarning: Dialect sqlite+pysqlite does *not* support Decimal objects natively, and SQLAlchemy must convert from floating point - rounding errors and other issues may occur. Please consider storing Decimal numbers as strings or integers on this platform for lossless storage.

We can avoid this and all the problems related to floating point / decimal numbers by storing the price as an integer representing the number of cents.

Add a migration for the database to introduce a new "price_cents" integer column, and remove the existing "price" column.

Change _StorageProductSample to transparently convert to and from this price_cents column:

 - in the constructor, accept a Decimal value in dollars, but transform it in cents when assigning to the price_cents field
 - add a price property that converts the raw price_cents value to dollars, which the rest of the code can use transparently

While at it, change how the json parser parses decimal number, when getting data from the CT API, so that we get Decimal objects instead of float objects (the change in triangle.py).  Adjust ProductInfo.price in model.py accordingly.  This way, we never deal with floats in the whole pipeline.