### PR TITLE
Fix --discard-equal default value

### DIFF
--- a/src/canadiantracker/scraper.py
+++ b/src/canadiantracker/scraper.py
@@ -161,7 +161,7 @@ def scrape_inventory(
     help="Discard the previous last samples when equal to new samples",
     is_flag=True,
     show_default=True,
-    default=True,
+    default=False,
 )
 def scrape_prices(db_path: str, older_than: int, discard_equal: bool) -> None:
     """


### PR DESCRIPTION
The --discard-equal option's behavior is currently the reverse of what it was intended to be (and what would make sense from the name).  The default behavior discards equal samples, and when you pass --discard-equal, it does not discard equal samples.  Fix that.