### PR TITLE
Fix: triangle returns product prices as int

### DIFF
--- a/src/canadiantracker/model.py
+++ b/src/canadiantracker/model.py
@@ -16,8 +16,8 @@ class ProductInfo:
             return None
 
         value = current_price["value"]
-        assert type(value) is decimal.Decimal
-        return value
+        assert type(value) in [decimal.Decimal, int]
+        return decimal.Decimal(value)
 
     @property
     def code(self) -> str:


### PR DESCRIPTION
The triangle API returns prices that end in `XXX.00` as integers in the response json. As such, python's json parser returns an integer and the scraper asserts a type validation.

Here is an excerpt of the log of a failed price scraping run:
```
  File "/home/jgalar/.cache/ct/tmp.ctscraper.2022-10-26.UEBR4k/CanadianTracker/src/canadiantracker/model.py", line 19, in price
    assert type(value) is decimal.Decimal
      self = {'_raw_payload': {'code': '0229435', 'active': True, 'sellable': True, 'orderable': False, 'originalPrice': None, 'currentPrice': {'value': 267}, 'displayWasLabel': False, 'badges': [], 'storeShelfLocation': None, 'fulfillment': {'availability': {'Corporate': {'MinOrderQty': 1, 'bopisETA': {'MinETA': '2022-10-29T00:00:00.000Z', 'MaxETA': '2022-10-30T00:00:00.000Z'}, 'sthETA': {'MinETA': '2022-10-31T00:00:00.000Z', 'MaxETA': '2022-11-01T00:00:00.000Z'}}, 'quantity': 0}, 'storePickUp': {'etaEarliest': None, 'enabled': True}, 'shipToHome': {'etaEarliest': None, 'etaLatest': None, 'enabled': True}}, 'partNumber': '27-7579', 'feeValue': Decimal('97.02'), 'priceMessage': [{'label': None, 'tooltip': None}], 'rebate': None, 'priceValidUntil': None, 'warrantyMessage': 'This product carries a 3 year exchange warranty redeemable at any Canadian Tire store.'}}
      current_price = {'value': 267}
      value = 267
```

The type check is reasonable, but we must handle the case where the API returns an `int`. We can then harmlessly create a `decimal` value from any of the two types.