### PR TITLE
Remove _SQLite3ProductRepository abstraction

### DIFF
--- a/src/canadiantracker/storage.py
+++ b/src/canadiantracker/storage.py
@@ -156,65 +156,6 @@ _StorageSku.samples = sqlalchemy.orm.relationship(
 )
 
 
-class ProductRepository:
-    def __init__(self):
-        # Use a factory method to get an instance.
-        raise NotImplementedError
-
-    def products(
-        self, codes: Iterable[str] | None = None
-    ) -> Iterator[model.ProductListingEntry]:
-        raise NotImplementedError
-
-    @property
-    def skus(self) -> Iterator[model.Sku]:
-        raise NotImplementedError
-
-    @property
-    def samples(self) -> Iterator[model.ProductInfoSample]:
-        raise NotImplementedError
-
-    def flush(self):
-        raise NotImplementedError
-
-    def vacuum(self):
-        raise NotImplementedError
-
-    def get_product_listing_by_code(self, product_id: str) -> model.ProductListingEntry:
-        raise NotImplementedError
-
-    def get_sku_by_code(self, sku_code: str) -> model.Sku:
-        raise NotImplementedError
-
-    def get_sku_by_formatted_code(self, sku_formatted_code: str) -> model.Sku:
-        raise NotImplementedError
-
-    def get_product_info_samples_by_code(
-        self, product_id: str
-    ) -> Iterator[model.ProductInfoSample]:
-        raise NotImplementedError
-
-    def add_product_listing_entry(
-        self, product_listing_entry: model.ProductListingEntry
-    ):
-        raise NotImplementedError
-
-    def add_sku(
-        self,
-        product: model.ProductListingEntry,
-        sku: model.Sku,
-    ):
-        raise NotImplementedError
-
-    def add_product_price_sample(
-        self, product_price_sample: model.ProductInfoSample
-    ) -> None:
-        raise NotImplementedError
-
-    def delete_sample(self, sample: model.ProductInfoSample):
-        raise NotImplementedError
-
-
 class InvalidDatabaseRevisionException(Exception):
     def __init__(self, msg: str):
         self._msg = msg
@@ -223,12 +164,12 @@ class InvalidDatabaseRevisionException(Exception):
         return f"Failed to validate database revision: {self._msg}"
 
 
-class _SQLite3ProductRepository(ProductRepository):
+class ProductRepository:
     ALEMBIC_REVISION = "ac8256c291d4"
 
     def __init__(self, path: str):
         db_url = "sqlite:///" + os.path.abspath(path)
-        logger.debug("Creating SQLite3ProductRepository with url `%s`", db_url)
+        logger.debug(f"Creating ProductRepository with url {db_url}")
         self._engine = sqlalchemy.create_engine(db_url, echo=False)
         inspector: sqlalchemy.engine.reflection.Inspector = sqlalchemy.inspect(
             self._engine
@@ -427,4 +368,4 @@ class _SQLite3ProductRepository(ProductRepository):
 
 
 def get_product_repository_from_sqlite_file(path: str) -> ProductRepository:
-    return _SQLite3ProductRepository(path)
+    return ProductRepository(path)

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -15,7 +15,7 @@ from canadiantracker import model, storage
 # Create a database in a temporary directory and initialize it with the
 # expected schema.  Return a repository object using that database.
 @pytest.fixture
-def repository(tmp_path: str) -> storage._SQLite3ProductRepository:
+def repository(tmp_path: str) -> storage.ProductRepository:
     sqlite_db_path = os.path.join(tmp_path, "inventory.db")
     engine = sqlalchemy.create_engine(f"sqlite:///{sqlite_db_path}")
     conn = engine.connect()
@@ -33,7 +33,7 @@ def repository(tmp_path: str) -> storage._SQLite3ProductRepository:
             list(
                 mc.script.iterate_revisions(
                     lower="base",
-                    upper=storage._SQLite3ProductRepository.ALEMBIC_REVISION,
+                    upper=storage.ProductRepository.ALEMBIC_REVISION,
                 )
             )
         )
@@ -49,15 +49,15 @@ def repository(tmp_path: str) -> storage._SQLite3ProductRepository:
         config,
         script,
         fn=do_upgrade,
-        destination_rev=storage._SQLite3ProductRepository.ALEMBIC_REVISION,
+        destination_rev=storage.ProductRepository.ALEMBIC_REVISION,
     ) as ec:
         ec.configure(connection=conn)
         ec.run_migrations()
 
-    return storage._SQLite3ProductRepository(sqlite_db_path)
+    return storage.ProductRepository(sqlite_db_path)
 
 
-def test_add_product(repository: storage._SQLite3ProductRepository):
+def test_add_product(repository: storage.ProductRepository):
     repository.add_product_listing_entry(
         model.ProductListingEntry("1234567", "Hello", False, "/foo")
     )


### PR DESCRIPTION
The _SQLite3ProductRepository is starting to have a whole lot of business logic, I don't think it's a good storage abstraction anymore. I suggest removing the base class.  If we want to introduce another database / storage abstraction layer, it could be underneath that layer.