### PR TITLE
Fix: scrape_products: unexpected keyword argument 'category_levels'

### DIFF
--- a/src/canadiantracker/scraper.py
+++ b/src/canadiantracker/scraper.py
@@ -76,6 +76,7 @@ def validate_category_levels(
 )
 @click.option(
     "--category-levels",
+    "opt_category_levels",
     type=str,
     callback=validate_category_levels,
     default=None,


### PR DESCRIPTION
Click provides options in a variable whose name is derived from the option name. Since 152eaf534d changed the name of the function parameter and it doesn't match that convention anymore, provide a name explicitly to Click.

Fixes #52

Signed-off-by: Jérémie Galarneau <jeremie.galarneau@gmail.com>