### PR TITLE
storage: fix data type of _StorageProductSample.sample_time

### DIFF
--- a/src/canadiantracker/storage.py
+++ b/src/canadiantracker/storage.py
@@ -101,7 +101,7 @@ class _StorageProductSample(_Base):
     __tablename__ = "samples"
 
     index: Mapped[int] = mapped_column(primary_key=True, unique=True, index=True)
-    sample_time: Mapped[datetime.date]
+    sample_time: Mapped[datetime.datetime]
     sku_index: Mapped[int] = mapped_column(
         sqlalchemy.ForeignKey("skus.index"),
         index=True,


### PR DESCRIPTION
The data type of the _StorageProductSample.sample_time attribute (which implies the type of the column in the database) is wrong.  It should be a datetime and not a date.  It causes this error:

    $ curl -i http://localhost:5001/api/skus/3995029/samples
    HTTP/1.1 500 Internal Server Error
    date: Thu, 16 Feb 2023 02:38:02 GMT
    server: uvicorn
    content-length: 21
    content-type: text/plain; charset=utf-8

    Internal Server Error%

And in the server logs:

    Traceback (most recent call last):
      File "/home/simark/.cache/pypoetry/virtualenvs/canadiantracker-A2nmWmCU-py3.10/lib/python3.10/site-packages/uvicorn/protocols/http/h11_impl.py", line 366, in run_asgi
        result = await app(self.scope, self.receive, self.send)
      File "/home/simark/.cache/pypoetry/virtualenvs/canadiantracker-A2nmWmCU-py3.10/lib/python3.10/site-packages/uvicorn/middleware/proxy_headers.py", line 75, in __call__
        return await self.app(scope, receive, send)
      File "/home/simark/.cache/pypoetry/virtualenvs/canadiantracker-A2nmWmCU-py3.10/lib/python3.10/site-packages/fastapi/applications.py", line 261, in __call__
        await super().__call__(scope, receive, send)
      File "/home/simark/.cache/pypoetry/virtualenvs/canadiantracker-A2nmWmCU-py3.10/lib/python3.10/site-packages/starlette/applications.py", line 112, in __call__
        await self.middleware_stack(scope, receive, send)
      File "/home/simark/.cache/pypoetry/virtualenvs/canadiantracker-A2nmWmCU-py3.10/lib/python3.10/site-packages/starlette/middleware/errors.py", line 181, in __call__
        raise exc
      File "/home/simark/.cache/pypoetry/virtualenvs/canadiantracker-A2nmWmCU-py3.10/lib/python3.10/site-packages/starlette/middleware/errors.py", line 159, in __call__
        await self.app(scope, receive, _send)
      File "/home/simark/.cache/pypoetry/virtualenvs/canadiantracker-A2nmWmCU-py3.10/lib/python3.10/site-packages/starlette/exceptions.py", line 82, in __call__
        raise exc
      File "/home/simark/.cache/pypoetry/virtualenvs/canadiantracker-A2nmWmCU-py3.10/lib/python3.10/site-packages/starlette/exceptions.py", line 71, in __call__
        await self.app(scope, receive, sender)
      File "/home/simark/.cache/pypoetry/virtualenvs/canadiantracker-A2nmWmCU-py3.10/lib/python3.10/site-packages/fastapi/middleware/asyncexitstack.py", line 21, in __call__
        raise e
      File "/home/simark/.cache/pypoetry/virtualenvs/canadiantracker-A2nmWmCU-py3.10/lib/python3.10/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
        await self.app(scope, receive, send)
      File "/home/simark/.cache/pypoetry/virtualenvs/canadiantracker-A2nmWmCU-py3.10/lib/python3.10/site-packages/starlette/routing.py", line 656, in __call__
        await route.handle(scope, receive, send)
      File "/home/simark/.cache/pypoetry/virtualenvs/canadiantracker-A2nmWmCU-py3.10/lib/python3.10/site-packages/starlette/routing.py", line 259, in handle
        await self.app(scope, receive, send)
      File "/home/simark/.cache/pypoetry/virtualenvs/canadiantracker-A2nmWmCU-py3.10/lib/python3.10/site-packages/starlette/routing.py", line 61, in app
        response = await func(request)
      File "/home/simark/.cache/pypoetry/virtualenvs/canadiantracker-A2nmWmCU-py3.10/lib/python3.10/site-packages/fastapi/routing.py", line 227, in app
        raw_response = await run_endpoint_function(
      File "/home/simark/.cache/pypoetry/virtualenvs/canadiantracker-A2nmWmCU-py3.10/lib/python3.10/site-packages/fastapi/routing.py", line 160, in run_endpoint_function
        return await dependant.call(**values)
      File "/home/simark/src/CanadianTracker/src/canadiantracker/http.py", line 80, in api_skus_samples
        return [serialize_product_info_sample(sample) for sample in sku.samples]
      File "/home/simark/.cache/pypoetry/virtualenvs/canadiantracker-A2nmWmCU-py3.10/lib/python3.10/site-packages/sqlalchemy/orm/attributes.py", line 562, in __get__
        return self.impl.get(state, dict_)  # type: ignore[no-any-return]
      File "/home/simark/.cache/pypoetry/virtualenvs/canadiantracker-A2nmWmCU-py3.10/lib/python3.10/site-packages/sqlalchemy/orm/attributes.py", line 1075, in get
        value = self._fire_loader_callables(state, key, passive)
      File "/home/simark/.cache/pypoetry/virtualenvs/canadiantracker-A2nmWmCU-py3.10/lib/python3.10/site-packages/sqlalchemy/orm/attributes.py", line 1110, in _fire_loader_callables
        return self.callable_(state, passive)
      File "/home/simark/.cache/pypoetry/virtualenvs/canadiantracker-A2nmWmCU-py3.10/lib/python3.10/site-packages/sqlalchemy/orm/strategies.py", line 948, in _load_for_state
        return self._emit_lazyload(
      File "/home/simark/.cache/pypoetry/virtualenvs/canadiantracker-A2nmWmCU-py3.10/lib/python3.10/site-packages/sqlalchemy/orm/strategies.py", line 1115, in _emit_lazyload
        result = result.unique().scalars().all()
      File "/home/simark/.cache/pypoetry/virtualenvs/canadiantracker-A2nmWmCU-py3.10/lib/python3.10/site-packages/sqlalchemy/engine/result.py", line 1774, in all
        return self._allrows()
      File "/home/simark/.cache/pypoetry/virtualenvs/canadiantracker-A2nmWmCU-py3.10/lib/python3.10/site-packages/sqlalchemy/engine/result.py", line 530, in _allrows
        rows = self._fetchall_impl()
      File "/home/simark/.cache/pypoetry/virtualenvs/canadiantracker-A2nmWmCU-py3.10/lib/python3.10/site-packages/sqlalchemy/engine/result.py", line 1676, in _fetchall_impl
        return self._real_result._fetchall_impl()
      File "/home/simark/.cache/pypoetry/virtualenvs/canadiantracker-A2nmWmCU-py3.10/lib/python3.10/site-packages/sqlalchemy/engine/result.py", line 2291, in _fetchall_impl
        return list(self.iterator)
      File "/home/simark/.cache/pypoetry/virtualenvs/canadiantracker-A2nmWmCU-py3.10/lib/python3.10/site-packages/sqlalchemy/orm/loading.py", line 190, in chunks
        fetch = cursor._raw_all_rows()
      File "/home/simark/.cache/pypoetry/virtualenvs/canadiantracker-A2nmWmCU-py3.10/lib/python3.10/site-packages/sqlalchemy/engine/result.py", line 522, in _raw_all_rows
        return [make_row(row) for row in rows]
      File "/home/simark/.cache/pypoetry/virtualenvs/canadiantracker-A2nmWmCU-py3.10/lib/python3.10/site-packages/sqlalchemy/engine/result.py", line 522, in <listcomp>
        return [make_row(row) for row in rows]
      File "lib/sqlalchemy/cyextension/resultproxy.pyx", line 24, in sqlalchemy.cyextension.resultproxy.BaseRow.__init__
      File "lib/sqlalchemy/cyextension/processors.pyx", line 45, in sqlalchemy.cyextension.processors.str_to_date
    ValueError: Invalid isoformat string: '2022-03-22 00:19:20.428851'