### PR TITLE
http: /skus/{sku_code}: raise 404 HTTPException if SKU is not found

### DIFF
--- a/src/canadiantracker/http.py
+++ b/src/canadiantracker/http.py
@@ -116,7 +116,9 @@ async def one_sku(
     request: Request, sku_code: str
 ) -> starlette.templating._TemplateResponse:
     sku = _repository.get_sku_by_code(sku_code)
-    assert sku
+    if sku is None:
+        raise HTTPException(status_code=404, detail="SKU not found")
+
     product_url = sku.product.url
     if product_url:
         sku_url = make_sku_url(sku.code, product_url)


### PR DESCRIPTION
We currently assert if the provided SKU number is not found, causing an internal server error.  Raise an HTTPException with status 404 instead.