### PR TITLE
sku.html: omit SKU link if there is no URL

### DIFF
--- a/src/canadiantracker/web/templates/sku.html
+++ b/src/canadiantracker/web/templates/sku.html
@@ -12,7 +12,9 @@
     <p>
         Name: {{ sku.product.name }}
         <br>
+        {% if sku_url %}
         <a href="https://canadiantire.ca{{ sku_url }}">{{ sku.formatted_code }}</a>
+        {% endif %}
     </p>
 
     <div id="price-history" style="width:600px;height:250px;"></div>


### PR DESCRIPTION
The `sku_url` variable that is passed to sku.html can be None (we may not know the URL for all SKUs).  The URL is currently printed unconditionally, leading to broken links like:

    https://canadiantire.canone

... if there is not URL.  Omit the link if there is not URL.